### PR TITLE
fix: Allow using reference as a verb

### DIFF
--- a/assets/imperatives_blacklist.txt
+++ b/assets/imperatives_blacklist.txt
@@ -61,7 +61,6 @@ new
 number
 optional
 placeholder
-reference
 result
 same
 schema


### PR DESCRIPTION
The blacklist entry for "reference" triggered a very unsightly workaround in https://github.com/ariel-os/ariel-os/pull/1703.

I think that unless tools have very accessible means for authors of text to acknowledge a concern but decide that it does not apply here, they should err on the side of tolerance: Requiring that authors rephrase "doc: reference this mechanism in that text" causes annoyance, while not rejecting "doc: reference added here and there" is part of language ambiguity for which there are human reviewers in the loop (and not much is lost if a single one slips through eventually).